### PR TITLE
PS4 Link support

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -169,6 +169,44 @@ void profile_saveLocal() {
 	sceIoClose(fd);
 }
 
+void profile_savePS4Link() {
+	SceUID fd;
+	// Just in case the folder doesn't exist
+	sceIoMkdir("ux0:/data/remaPSV", 0777); 
+	sprintf(fname, "ux0:/data/remaPSV/NPXS10013");
+	sceIoMkdir(fname, 0777);
+	
+	// Opening remap config file and saving it
+	sprintf(fname, "ux0:/data/remaPSV/NPXS10013/remap.bin");
+	fd = sceIoOpen(fname, SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
+	sceIoWrite(fd, profile_remap, PROFILE_REMAP_NUM);
+	sceIoClose(fd);
+	
+	// Opening analog config file and saving the config
+	sprintf(fname, "ux0:/data/remaPSV/NPXS10013/analogs.bin");
+	fd = sceIoOpen(fname, SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
+	sceIoWrite(fd, profile_analog, PROFILE_ANALOG_NUM);
+	sceIoClose(fd);
+	
+	// Opening touch config file and saving the config
+	sprintf(fname, "ux0:/data/remaPSV/NPXS10013/touch.bin");
+	fd = sceIoOpen(fname, SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
+	sceIoWrite(fd, profile_touch, PROFILE_TOUCH_NUM*2);
+	sceIoClose(fd);
+	
+	// Opening gyro config file and saving the config
+	sprintf(fname, "ux0:/data/remaPSV/NPXS10013/gyro.bin");
+	fd = sceIoOpen(fname, SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
+	sceIoWrite(fd, profile_gyro, PROFILE_GYRO_NUM);
+	sceIoClose(fd);
+	
+	// Opening gyro config file and saving the config
+	sprintf(fname, "ux0:/data/remaPSV/NPXS10013/controllers.bin");
+	fd = sceIoOpen(fname, SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
+	sceIoWrite(fd, profile_controller, PROFILE_CONTROLLER_NUM);
+	sceIoClose(fd);
+}
+
 void profile_loadGlobal() {
 	profile_resetRemap();
 	profile_resetAnalog();

--- a/src/profile.h
+++ b/src/profile.h
@@ -35,8 +35,8 @@ extern void profile_saveSettings();
 extern void profile_loadSettings();
 extern void profile_saveGlobal();
 extern void profile_saveLocal();
+extern void profile_savePS4Link();
 extern void profile_loadGlobal();
 extern void profile_loadLocal();
-extern void profile_savePS4Link();
 
 #endif

--- a/src/profile.h
+++ b/src/profile.h
@@ -37,5 +37,6 @@ extern void profile_saveGlobal();
 extern void profile_saveLocal();
 extern void profile_loadGlobal();
 extern void profile_loadLocal();
+extern void profile_savePS4Link();
 
 #endif

--- a/src/ui.c
+++ b/src/ui.c
@@ -844,6 +844,8 @@ void ui_inputHandler(SceCtrlData *ctrl) {
 						profile_saveGlobal();			
 					} else if (cfg_i == PROFILE_SETTINGS_NUM + 3) {
 						profile_loadGlobal();			
+					} else if (cfg_i == PROFILE_SETTINGS_NUM + 4) {
+						profile_savePS4Link();			
 					}
 				} else if (menu_i == GYRO_MENU) {
 					if (cfg_i == 10)

--- a/src/ui.c
+++ b/src/ui.c
@@ -104,7 +104,8 @@ static char* str_settings[] = {
 	"Save as Game profile", 
 	"Load Game profile", 
 	"Save as Global profile", 
-	"Load Global profile"
+	"Load Global profile",
+	"Save as PS4 Link profile"
 };
 
 static char* str_funcs[HOOKS_NUM-1] = {


### PR DESCRIPTION
Ввиду того, что приложение невозможно отобразить во время использования PS4 Link, предлагаю реализацию в обход - возможность сохранения профиля из другого приложения вместо использования глобальных настроек. Изменения не проверены лично, но достаточно примитивны по своей сути.